### PR TITLE
add .gitattributes and set manual override for language classification of .d files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.d linguist-language=Objective-C


### PR DESCRIPTION
i _think_ this will ensure that the project is categorized by GitHub as Objective-C.

cc/ @nixta

the more labor intensive option would be to remove the unnecessary files from version control and just ensure that the doc explains to folks what the pre-requisites are to be able to run the sample.